### PR TITLE
fix(tskit): use bundler moduleResolution so typecheck passes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,3 +58,24 @@ jobs:
 
       - name: Build
         run: pnpm -r run build
+
+  typecheck:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pnpm
+        run: |
+          npm install -g corepack@latest --force
+          corepack enable
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.16.0'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Typecheck
+        run: pnpm -r run typecheck

--- a/packages/tskit/tsconfig.json
+++ b/packages/tskit/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2018",
     "module": "esnext",
     "lib": ["esnext", "DOM"],
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "strict": true,
     "strictNullChecks": true,


### PR DESCRIPTION
## What

\`moduleResolution: "node"\` resolves to the \`node10\` mode that TypeScript 6.0 deprecated, so \`pnpm run typecheck\` (a documented dev command) fails with **TS5107**. Switch to \`bundler\`, which matches the \`module: "esnext"\` + tsdown bundling setup.

Also adds a dedicated **typecheck** job to CI so this class of regression is caught.

## Verify
- \`pnpm run typecheck\` ✅ (was failing)
- \`pnpm run build\` ✅
- 116 tests ✅

> Note: this PR and `chore/eslint-config` both append a CI job after the Build step — whichever merges second will have a trivial `test.yml` conflict (keep both jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)