### PR TITLE
refactor(tskit): simplify has() path lookup and moneyFormat() padding

### DIFF
--- a/packages/tskit/src/has.ts
+++ b/packages/tskit/src/has.ts
@@ -12,7 +12,7 @@ export const has = (obj: TObject, key: string): boolean => {
   return (
     !!obj &&
     (keyParts.length > 1
-      ? has(obj[key.split('.')[0]], keyParts.slice(1).join('.'))
+      ? has(obj[keyParts[0]], keyParts.slice(1).join('.'))
       : hasOwnProperty.call(obj, key))
   )
 }

--- a/packages/tskit/src/moneyFormat.ts
+++ b/packages/tskit/src/moneyFormat.ts
@@ -21,8 +21,9 @@ export function moneyFormat(number: Numeric, decimals = 0) {
     s[0] = s[0].replace(re, `$1${sep}$2`)
   }
 
-  if ((s[1] || '').length < prec) {
-    s[1] = (s[1] || '').padEnd(prec, '0')
+  const decimal = s[1] || ''
+  if (decimal.length < prec) {
+    s[1] = decimal.padEnd(prec, '0')
   }
 
   return s.join(dec)

--- a/packages/tskit/src/moneyFormat.ts
+++ b/packages/tskit/src/moneyFormat.ts
@@ -22,8 +22,7 @@ export function moneyFormat(number: Numeric, decimals = 0) {
   }
 
   if ((s[1] || '').length < prec) {
-    s[1] = s[1] || ''
-    s[1] += Array.from({ length: prec - s[1].length + 1 }).join('0')
+    s[1] = (s[1] || '').padEnd(prec, '0')
   }
 
   return s.join(dec)


### PR DESCRIPTION
## What
- \`has()\`: reuse the already-computed \`keyParts[0]\` instead of splitting the key string a second time.
- \`moneyFormat()\`: pad the decimal part with \`String.prototype.padEnd\` instead of the off-by-one \`Array.from({ length }).join('0')\` trick.

Behaviour is unchanged — verified across whole / short / long decimal cases.

## Verify
- 116 tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)