### PR TITLE
ci: stop running every job twice per push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,13 +3,15 @@ name: CI
 on:
   push:
     branches:
-      - '**'
-
-  pull_request:
-    branches:
       - main
 
+  pull_request:
+
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:


### PR DESCRIPTION
## Problem
\`push: ['**']\` matched every branch while \`pull_request\` also fired for the same commit, so pushing to a branch that has an open PR ran **build / test / typecheck twice** (the \`(push)\` + \`(pull_request)\` duplicates).

## Fix
- Limit \`push\` to \`main\` — runs once after merge / on direct-to-main pushes.
- Keep \`pull_request\` for all PR validation.
- Add a \`concurrency\` group so a newer push cancels the superseded in-progress run.

Trade-off: pushing to a feature branch **without** an open PR no longer triggers CI; it runs as soon as a PR is opened.

> Only touches the \`on:\` trigger block, so it doesn't conflict with the job additions in #300 / #302 / #303.