### PR TITLE
chore(renovate): pin typescript below v7 until typescript-eslint supports it

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,5 +3,13 @@
   extends: ['config:recommended'],
   rangeStrategy: 'bump',
   dependencyDashboard: false,
-  schedule: ['after 4pm on friday']
+  schedule: ['after 4pm on friday'],
+  packageRules: [
+    {
+      // TS 7.0 ships no compiler API, so typescript-eslint throws on major >= 7.
+      // Lift this once https://github.com/typescript-eslint/typescript-eslint/issues/10940 ships.
+      matchPackageNames: ['typescript'],
+      allowedVersions: '<7'
+    }
+  ]
 }


### PR DESCRIPTION
TypeScript 7.0 ships no compiler API, so typescript-eslint deliberately throws when ts.versionMajorMinor major is >= 7, breaking the lint job. No published version helps: even the 8.67.1-alpha canary still declares "typescript": ">=4.8.4 <6.1.0".

Refs https://github.com/typescript-eslint/typescript-eslint/issues/10940